### PR TITLE
Se aplican permisos de nivel de vista

### DIFF
--- a/musica/artista/views.py
+++ b/musica/artista/views.py
@@ -3,11 +3,11 @@ from rest_framework import serializers, viewsets
 from artista.models import Artista
 from .serializers import ArtistaSerializer
 
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 
 class ArtistaViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     serializer_class = ArtistaSerializer
     queryset = Artista.objects.all()

--- a/musica/canciones/views.py
+++ b/musica/canciones/views.py
@@ -3,11 +3,11 @@ from rest_framework import viewsets
 from .models import Cancion, Autor, Album
 from .serializers import CancionSerializer, AutorSerializer, AlbumSerializer
 
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 
 class CancionViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     serializer_class = CancionSerializer
     queryset = Cancion.objects.all()

--- a/musica/disquera/views.py
+++ b/musica/disquera/views.py
@@ -3,11 +3,11 @@ from rest_framework import viewsets
 from .models import Disquera
 from .serializers import DisqueraSerializer
 
-from rest_framework.permissions import IsAuthenticated
+from rest_framework.permissions import IsAuthenticatedOrReadOnly
 
 
 class DisqueraViewSet(viewsets.ModelViewSet):
-    permission_classes = (IsAuthenticated,)
+    permission_classes = (IsAuthenticatedOrReadOnly,)
 
     serializer_class = DisqueraSerializer
     queryset = Disquera.objects.all()

--- a/musica/musica/settings.py
+++ b/musica/musica/settings.py
@@ -121,5 +121,9 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'rest_framework.authentication.BasicAuthentication',
         'rest_framework.authentication.SessionAuthentication',
+    ),
+
+    'DEFAULT_PERMISSION_CLASSES': (
+        'rest_framework.permissions.AllowAny',
     )
 }

--- a/musica/musica/urls.py
+++ b/musica/musica/urls.py
@@ -6,4 +6,5 @@ urlpatterns = [
     path('artista/', include('artista.urls')),
     path('disquera/', include('disquera.urls')),
     path('admin/', admin.site.urls),
+    path('api-auth/', include('rest_framework.urls')),
 ]


### PR DESCRIPTION
Se aplican permisos de nivel de vista a las apps: Canciones, Artista y Disquera. Cualquier usuario puede ver lista completa y el detalle de cada una de ellas, y solo los usuarios logueados pueden registrar, editar y eliminar